### PR TITLE
add proxyprotocol support to prober

### DIFF
--- a/cmd/probe.go
+++ b/cmd/probe.go
@@ -55,8 +55,8 @@ setting the SNI (Server Name Indication) for the TLS handshake.`,
 				pp = "v2"
 			}
 			proberOptions := probe.ProbeOptions{
-				Endpoint:      endpoint,
-				ProxyProtocol: pp,
+				Endpoint:          endpoint,
+				ProxyProtocolMode: probe.ProxyProtocolMode(pp),
 			}
 
 			if probeOpts.sni != "" {

--- a/cmd/probe.go
+++ b/cmd/probe.go
@@ -47,16 +47,16 @@ setting the SNI (Server Name Indication) for the TLS handshake.`,
 			}
 			endpoint := args[0]
 
-			pp := ""
+			var ppMode probe.ProxyProtocolMode
 			if probeOpts.ppv1 {
-				pp = "v1"
+				ppMode = probe.ProxyProtocolV1
 			}
 			if probeOpts.ppv2 {
-				pp = "v2"
+				ppMode = probe.ProxyProtocolV2
 			}
 			proberOptions := probe.ProbeOptions{
 				Endpoint:          endpoint,
-				ProxyProtocolMode: probe.ProxyProtocolMode(pp),
+				ProxyProtocolMode: probe.ProxyProtocolMode(ppMode),
 			}
 
 			if probeOpts.sni != "" {

--- a/cmd/probe.go
+++ b/cmd/probe.go
@@ -26,26 +26,37 @@ import (
 )
 
 type probeOptions struct {
-	verbose bool
-	sni     string
+	verbose    bool
+	ppv1, ppv2 bool
+	sni        string
 }
 
 var probeOpts probeOptions
 
 func probeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "probe [--verbose] [--sni server-name] endpoint",
+		Use:   "probe [--verbose] [--proxy-protocol-v1|--proxy-protocol-v2] [--sni server-name] endpoint",
 		Short: "Probe a given endpoint",
 		Long: `Probe will open a TLS connection to an endpoint.
-It will report details on DNS resolving (chain of CNAMEs / A records).`,
+It will report details on DNS resolving (chain of CNAMEs / A records).
+The command also supports sending proxy protocol headers (v1/v2) and
+setting the SNI (Server Name Indication) for the TLS handshake.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("endpoint expected as argument")
 			}
 			endpoint := args[0]
 
+			pp := ""
+			if probeOpts.ppv1 {
+				pp = "v1"
+			}
+			if probeOpts.ppv2 {
+				pp = "v2"
+			}
 			proberOptions := probe.ProbeOptions{
-				Endpoint: endpoint,
+				Endpoint:      endpoint,
+				ProxyProtocol: pp,
 			}
 
 			if probeOpts.sni != "" {
@@ -77,6 +88,8 @@ It will report details on DNS resolving (chain of CNAMEs / A records).`,
 	}
 
 	cmd.Flags().BoolVar(&probeOpts.verbose, "verbose", false, "be verbose, output logs")
+	cmd.Flags().BoolVar(&probeOpts.ppv1, "proxy-protocol-v1", false, "send proxy protocol v1 headers")
+	cmd.Flags().BoolVar(&probeOpts.ppv2, "proxy-protocol-v2", false, "send proxy protocol v2 headers")
 	cmd.Flags().StringVar(&probeOpts.sni, "sni", "", "set SNI for TLS handshake (defaults to endpoint host)")
 
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.2
 
 require (
 	github.com/paraopsde/go-x/pkg/util v0.0.0-20240129084514-06e150c57be2
+	github.com/pires/go-proxyproto v0.8.0
 	github.com/spf13/cobra v1.8.1
 	go.uber.org/zap v1.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/paraopsde/go-x/pkg/util v0.0.0-20240129084514-06e150c57be2 h1:tLyFW9rcIjtoAOUK6TJE/XuFkfakXVD7jDVGUzlUAV4=
 github.com/paraopsde/go-x/pkg/util v0.0.0-20240129084514-06e150c57be2/go.mod h1:yJa4IAiKhu3wZpkdSkyhAHSZQfdbR7+46SH3y+TInMo=
+github.com/pires/go-proxyproto v0.8.0 h1:5unRmEAPbHXHuLjDg01CxJWf91cw3lKHc/0xzKpXEe0=
+github.com/pires/go-proxyproto v0.8.0/go.mod h1:iknsfgnH8EkjrMeMyvfKByp9TiBZCKZM0jx2xmKqnVY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -192,7 +192,7 @@ func (p *prober) maybeSendProxyProtocolHeaders(ctx context.Context, signals chan
 		return
 	}
 
-	if p.proxyProtocolMode == "v2" {
+	if p.proxyProtocolMode == ProxyProtocolV2 {
 		if err := p.sendProxyProtocolV2Headers(ctx, localIp, remoteIp, localPort, remotePort); err != nil {
 			signals <- Signal{Path: "PROXYPROTOCOL/V2/ERROR", Error: err}
 		} else {

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/paraopsde/go-x/pkg/util"
@@ -66,12 +65,11 @@ func NewProber(o ProbeOptions) (*prober, error) {
 		proxyProtocolMode: o.ProxyProtocolMode,
 		sni:               o.ServerNameIndication,
 	}
-	parts := strings.Split(p.endpoint, ":")
-	if len(parts) != 2 {
+	var err error
+	p.fqdn, p.port, err = net.SplitHostPort(p.endpoint)
+	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint '%s'", p.endpoint)
 	}
-	p.fqdn = parts[0]
-	p.port = parts[1]
 
 	if p.sni == "" {
 		p.sni = p.fqdn


### PR DESCRIPTION
add proxy protocol support to the prober

Adds the capability of the prober to send proxy protocol headers
(v1/v2) before continuing with the TLS handshake.
