### PR TITLE
unify capture acquire; add pcap to darwin/macos

### DIFF
--- a/pkg/capture/acquire.go
+++ b/pkg/capture/acquire.go
@@ -47,7 +47,7 @@ func (s *SNICapturer) acquireCaptureHandle() (*gopacket.PacketSource, error) {
 			}
 		}
 		return gopacket.NewPacketSource(handle, handle.LinkType()), nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported type %s", errInvalidConfig, s.captureType)
 	}
-
-	return nil, fmt.Errorf("%w: unsupported type %s", errInvalidConfig, s.captureType)
 }

--- a/pkg/capture/acquire.go
+++ b/pkg/capture/acquire.go
@@ -47,6 +47,8 @@ func (s *SNICapturer) acquireCaptureHandle() (*gopacket.PacketSource, error) {
 			}
 		}
 		return gopacket.NewPacketSource(handle, handle.LinkType()), nil
+	case CaptureTypeAfpacket:
+		return s.acquireCaptureHandle_afpacket()
 	default:
 		return nil, fmt.Errorf("%w: unsupported type %s", errInvalidConfig, s.captureType)
 	}

--- a/pkg/capture/acquire_darwin.go
+++ b/pkg/capture/acquire_darwin.go
@@ -1,0 +1,26 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+// +build darwin
+
+package capture
+
+import (
+	"fmt"
+
+	"github.com/google/gopacket"
+)
+
+func (s *SNICapturer) acquireCaptureHandle_afpacket() (*gopacket.PacketSource, error) {
+	return nil, fmt.Errorf("%w: AF_PACKET type not supported on darwin OS", errInvalidConfig)
+}

--- a/pkg/capture/acquire_linux.go
+++ b/pkg/capture/acquire_linux.go
@@ -25,43 +25,28 @@ import (
 	"golang.org/x/net/bpf"
 )
 
-var errInvalidConfig = fmt.Errorf("invalid config")
-
-func (s *SNICapturer) acquireCaptureHandle() (*gopacket.PacketSource, error) {
-	switch s.captureType { //nolint:exhaustive
-	case "pcap":
-		pcapHandle, err := pcap.OpenLive(s.ifaceName, 2000, false, pcap.BlockForever)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open interface %s: %w", s.ifaceName, err)
-		}
-		if s.bpfFilter != "" {
-			err = pcapHandle.SetBPFFilter(s.bpfFilter)
-			if err != nil {
-				return nil, fmt.Errorf("failed to set bpf filter %s: %w", s.bpfFilter, err)
-			}
-		}
-		s.packetSource = gopacket.NewPacketSource(pcapHandle, pcapHandle.LinkType())
-	case "afpacket":
-		afpHandle, err := afpacket.NewTPacket(
-			afpacket.OptInterface(s.ifaceName),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open interface %s: %w", s.ifaceName, err)
-		}
-		if s.bpfFilter != "" {
-			bpfInstr, err := compilePfg(s.bpfFilter, 2000)
-			if err != nil {
-				return nil, fmt.Errorf("failed to compile bpf filter %s: %w", s.bpfFilter, err)
-			}
-			err = afpHandle.SetBPF(bpfInstr)
-			if err != nil {
-				return nil, fmt.Errorf("failed to set bpf filter %s: %w", s.bpfFilter, err)
-			}
-		}
-		return gopacket.NewPacketSource(afpHandle, layers.LinkTypeEthernet), nil
+func (s *SNICapturer) acquireCaptureHandle_afpacket() (*gopacket.PacketSource, error) {
+	if s.captureType != CaptureTypeAfpacket {
+		return nil, fmt.Errorf("%w: unsupported type %s", errInvalidConfig, s.captureType)
 	}
 
-	return nil, fmt.Errorf("%w: unsupported type %s", errInvalidConfig, s.captureType)
+	afpHandle, err := afpacket.NewTPacket(
+		afpacket.OptInterface(s.ifaceName),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open interface %s: %w", s.ifaceName, err)
+	}
+	if s.bpfFilter != "" {
+		bpfInstr, err := compilePfg(s.bpfFilter, 2000)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile bpf filter %s: %w", s.bpfFilter, err)
+		}
+		err = afpHandle.SetBPF(bpfInstr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set bpf filter %s: %w", s.bpfFilter, err)
+		}
+	}
+	return gopacket.NewPacketSource(afpHandle, layers.LinkTypeEthernet), nil
 }
 
 func compilePfg(filter string, snaplen int) ([]bpf.RawInstruction, error) {


### PR DESCRIPTION
- adds pcap capture support for macos / darwin
- adds bpf to pcap-file type
- fix bug which returned error on pcap type on linux
- moves pcap/pcap-file types to os independent code (shared linux/darwin)
